### PR TITLE
update docs, check for typos and other inconsistencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,5 +11,5 @@ https://github.com/akamai-api/golang/tree/master/docs
 ## Dependency Management
 
 This project uses [dep](https://github.com/golang/dep "github.com") for dependency management.
-See the README of dep for installation instructions: [https://github.com/golang/dep#setup](https://github.com/golang/dep#setup "github.com")
+See the README of dep for installation instructions: [https://github.com/golang/dep#setup](https://github.com/golang/dep#setup "github.com").
 Execute `dep ensure [-update]` for installing/updating dependencies.

--- a/docs/docker-compose.md
+++ b/docs/docker-compose.md
@@ -3,16 +3,16 @@
 
 ## Instructions
 * Make sure docker engine is installed ([instructions](https://docs.docker.com/engine/installation/))
-* Make sure docker compose is installed ([instructions](https://docs.docker.com/compose/install/))
+* Make sure docker-compose is installed ([instructions](https://docs.docker.com/compose/install/))
 
-* Start containers by running `docker-compose up`
+* Start services/containers by running `docker-compose up`
 
-Now we have 3 docker containers running with:
-* run arbitratry commands in your services using `docker-compose exec <service>` e.g 
+Now we have 3 docker containers running.
+* run arbitratry commands in your services using `docker-compose exec <service> <command>` e.g. 
 ```
 docker-compose exec influxDB bash
 ```
-* Recreate containers even if their configuration and image haven't changed using 
+* Recreate containers even if their configuration and image haven't changed using :  
 ```
 docker-compose up --force-recreate
 ```
@@ -28,11 +28,11 @@ cd tests
 Now visit local [grafana](http://localhost:3000) instance and login with admin/admin
 
 
-## How to access to the bash script in certain contaner
+## How to access the bash terminal in a certain container
  ```
  docker run -it server:latest bash
  ```
-## How to build a compooser again with building the containers at the same time
+## How to rebuild images before recreating the containers
 ```
 docker-compose up --force-recreate --build
 ```

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -4,7 +4,7 @@ In this documentation we illustrate how to create a web-host running on the dock
 
 ## Run
 ```
-go run server.go
+go run server.go types.go
 ```
 
 ## Build
@@ -17,18 +17,18 @@ go build
 ./Your-Root-Folder-Name
 ```
 
-## Build Docker
+## Build Docker Image
 
 ```
 docker build -t go-server .
 ```
 
-## Run Docker
+## Run Docker Container
 ```
 docker run --publish 9143:9143 -t  go-server
 ```
 
-## Check if your docker is running correctly
+## Check if your docker Container is running correctly
 ```
 docker ps
 ```


### PR DESCRIPTION
run server with `go run server.go types.go` updated in our documentation